### PR TITLE
fix: use Russian voice for Edge-TTS in horoscope project

### DIFF
--- a/projects/youtube_horoscope/config.yaml
+++ b/projects/youtube_horoscope/config.yaml
@@ -34,7 +34,7 @@ audio:
   engines:
     edge-tts:
       enabled: true
-      voice: en-US-AriaNeural
+      voice: ru-RU-DariyaNeural
       speed: 1.0
     gemini-tts:
       enabled: false


### PR DESCRIPTION
Bug Fix: Workflow #4 Failure

Problem:
part1-test.yml workflow #4 was failing because config.yaml used English voice (en-US-AriaNeural) for Edge-TTS, but the project generates Russian content.

Solution:
Changed Edge-TTS voice from en-US-AriaNeural to ru-RU-DariyaNeural for Russian text synthesis.

This fixes the TTS synthesis failure in the workflow.